### PR TITLE
feat: scaffold react frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,24 @@
-# medic
+# Medic
+
+This repository contains the frontend for the Medic device management system.
+
+## Frontend
+
+The React application lives under `frontend/` and follows a clean architecture folder structure:
+
+```
+frontend/
+  src/
+    application/    # application services and context
+    domain/          # domain entities
+    presentation/    # UI components, pages, routes
+```
+
+To run the development server:
+
+```bash
+cd frontend
+npm install
+npm run dev
+```
+

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Medic App</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "medic-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.22.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.21",
+    "@types/react-dom": "^18.2.7",
+    "@vitejs/plugin-react": "^4.0.0",
+    "typescript": "^5.2.2",
+    "vite": "^5.0.0"
+  }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import AppRoutes from './presentation/routes';
+
+const App: React.FC = () => {
+  return <AppRoutes />;
+};
+
+export default App;

--- a/frontend/src/application/context/AuthContext.tsx
+++ b/frontend/src/application/context/AuthContext.tsx
@@ -1,0 +1,24 @@
+import React, { createContext, useContext, useState } from 'react';
+import { User } from '../../domain/entities/user';
+
+interface AuthContextValue {
+  user?: User;
+  setUser: (user?: User) => void;
+}
+
+const AuthContext = createContext<AuthContextValue | undefined>(undefined);
+
+export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [user, setUser] = useState<User | undefined>();
+  return (
+    <AuthContext.Provider value={{ user, setUser }}>
+      {children}
+    </AuthContext.Provider>
+  );
+};
+
+export const useAuth = (): AuthContextValue => {
+  const context = useContext(AuthContext);
+  if (!context) throw new Error('useAuth must be used within AuthProvider');
+  return context;
+};

--- a/frontend/src/application/services/apiClient.ts
+++ b/frontend/src/application/services/apiClient.ts
@@ -1,0 +1,16 @@
+export const API_BASE_URL = '/api';
+
+export async function apiClient<T>(endpoint: string, options?: RequestInit): Promise<T> {
+  const response = await fetch(`${API_BASE_URL}${endpoint}`, {
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    ...options,
+  });
+
+  if (!response.ok) {
+    throw new Error('API error');
+  }
+
+  return response.json() as Promise<T>;
+}

--- a/frontend/src/domain/entities/device.ts
+++ b/frontend/src/domain/entities/device.ts
@@ -1,0 +1,5 @@
+export interface Device {
+  id: number;
+  serialNumber: string;
+  model: string;
+}

--- a/frontend/src/domain/entities/user.ts
+++ b/frontend/src/domain/entities/user.ts
@@ -1,0 +1,7 @@
+export type UserRole = 'Admin' | 'Technician' | 'Warehouse' | 'Staff';
+
+export interface User {
+  id: number;
+  name: string;
+  role: UserRole;
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,0 +1,25 @@
+body {
+  margin: 0;
+  font-family: sans-serif;
+}
+
+.navbar {
+  background-color: #1976d2;
+  color: #fff;
+  padding: 1rem;
+}
+
+.app-body {
+  display: flex;
+}
+
+.sidebar {
+  width: 200px;
+  background-color: #f5f5f5;
+  padding: 1rem;
+}
+
+.app-content {
+  flex: 1;
+  padding: 1rem;
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
+import App from './App';
+import { AuthProvider } from './application/context/AuthContext';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <BrowserRouter>
+      <AuthProvider>
+        <App />
+      </AuthProvider>
+    </BrowserRouter>
+  </React.StrictMode>
+);

--- a/frontend/src/presentation/components/layout/Layout.tsx
+++ b/frontend/src/presentation/components/layout/Layout.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { Outlet } from 'react-router-dom';
+import Navbar from './Navbar';
+import Sidebar from './Sidebar';
+
+const Layout: React.FC = () => (
+  <div className="app-layout">
+    <Navbar />
+    <div className="app-body">
+      <Sidebar />
+      <main className="app-content">
+        <Outlet />
+      </main>
+    </div>
+  </div>
+);
+
+export default Layout;

--- a/frontend/src/presentation/components/layout/Navbar.tsx
+++ b/frontend/src/presentation/components/layout/Navbar.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+const Navbar: React.FC = () => (
+  <header className="navbar">
+    <h1>Medic</h1>
+  </header>
+);
+
+export default Navbar;

--- a/frontend/src/presentation/components/layout/Sidebar.tsx
+++ b/frontend/src/presentation/components/layout/Sidebar.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+const Sidebar: React.FC = () => (
+  <aside className="sidebar">
+    <nav>
+      <ul>
+        <li><Link to="/">Dashboard</Link></li>
+      </ul>
+    </nav>
+  </aside>
+);
+
+export default Sidebar;

--- a/frontend/src/presentation/pages/DashboardPage.tsx
+++ b/frontend/src/presentation/pages/DashboardPage.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+const DashboardPage: React.FC = () => {
+  return (
+    <div>
+      <h2>Dashboard</h2>
+      {/* TODO: show upcoming assignments */}
+    </div>
+  );
+};
+
+export default DashboardPage;

--- a/frontend/src/presentation/pages/LoginPage.tsx
+++ b/frontend/src/presentation/pages/LoginPage.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+const LoginPage: React.FC = () => {
+  return (
+    <div>
+      <h2>Login</h2>
+      {/* TODO: implement login form */}
+    </div>
+  );
+};
+
+export default LoginPage;

--- a/frontend/src/presentation/routes/index.tsx
+++ b/frontend/src/presentation/routes/index.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { Routes, Route } from 'react-router-dom';
+import LoginPage from '../pages/LoginPage';
+import DashboardPage from '../pages/DashboardPage';
+import Layout from '../components/layout/Layout';
+
+const AppRoutes: React.FC = () => (
+  <Routes>
+    <Route path="/login" element={<LoginPage />} />
+    <Route element={<Layout />}>
+      <Route path="/" element={<DashboardPage />} />
+    </Route>
+  </Routes>
+);
+
+export default AppRoutes;

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/frontend/tsconfig.node.json
+++ b/frontend/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 3000
+  }
+});


### PR DESCRIPTION
## Summary
- scaffold React-based frontend with Vite and TypeScript
- set up clean architecture directories (application, domain, presentation)
- add basic routing, layout, and auth context skeleton

## Testing
- `npm install` (fails: 403 Forbidden - GET https://registry.npmjs.org/@types%2freact)`

------
https://chatgpt.com/codex/tasks/task_e_6899a76928948327a0088ce888befae5